### PR TITLE
Add support for natural-language-processing

### DIFF
--- a/src/Model/Callback/Message.php
+++ b/src/Model/Callback/Message.php
@@ -30,6 +30,11 @@ class Message
     protected $attachments;
 
     /**
+     * @var null|array
+     */
+    protected $entities;
+
+    /**
      * Message constructor.
      *
      * @param string $messageId
@@ -41,6 +46,7 @@ class Message
     public function __construct(
         string $messageId,
         int $sequence,
+        array $entities = [],
         string $text = null,
         string $quickReply = null,
         array $attachments = []
@@ -50,6 +56,7 @@ class Message
         $this->text = $text;
         $this->quickReply = $quickReply;
         $this->attachments = $attachments;
+        $this->entities = $entities;
     }
 
     /**
@@ -101,11 +108,19 @@ class Message
     }
 
     /**
-     * @return array
-     */
+        * @return array
+        */
     public function getAttachments(): array
     {
         return $this->attachments;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEntities(): array
+    {
+        return $this->entities;
     }
 
     /**
@@ -127,6 +142,13 @@ class Message
         $quickReply = $callbackData['quick_reply']['payload'] ?? null;
         $attachments = $callbackData['attachments'] ?? [];
 
-        return new static($callbackData['mid'], $callbackData['seq'], $text, $quickReply, $attachments);
+        return new static(
+            $callbackData['mid'],
+            $callbackData['seq'],
+            isset($callbackData['nlp']) ? $callbackData['nlp'] : null,
+            $text,
+            $quickReply,
+            $attachments
+        );
     }
 }

--- a/src/Model/Callback/Message.php
+++ b/src/Model/Callback/Message.php
@@ -145,7 +145,7 @@ class Message
         return new static(
             $callbackData['mid'],
             $callbackData['seq'],
-            isset($callbackData['nlp']) ? $callbackData['nlp'] : null,
+            isset($callbackData['nlp']) ? $callbackData['nlp']['entities'] : null,
             $text,
             $quickReply,
             $attachments


### PR DESCRIPTION
Within Facebook Messenger it's possible to enable natural-language-processing. You can simply add your wit.ai access token and Facebook will also send the NLP entities with the message.

Currently this isn't supported by this framework. With this commit I've implemented the NLP entities in the Message object from the Facebook Messenger API.