### PR TITLE
Update ButtonTemplate.php

### DIFF
--- a/src/Model/Message/Attachment/Template/ButtonTemplate.php
+++ b/src/Model/Message/Attachment/Template/ButtonTemplate.php
@@ -30,7 +30,7 @@ class ButtonTemplate extends Template
     {
         parent::__construct();
 
-        $this->isValidString($text, 320);
+        $this->isValidString($text, 640);
         $this->isValidArray($buttons, 3);
 
         $this->text = $text;


### PR DESCRIPTION
The 'button' template type takes up to 640 characters on the 'text' field but this class is limiting it to just 320.

Reference documentation: https://developers.facebook.com/docs/messenger-platform/reference/template/button