### PR TITLE
Removing the minimum of 1 element in QuickReplies array

### DIFF
--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -126,7 +126,7 @@ class Message implements \JsonSerializable
      */
     private function isValidQuickReplies(array $quickReplies): void
     {
-        $this->isValidArray($quickReplies, 11, 1);
+        $this->isValidArray($quickReplies, 11);
         foreach ($quickReplies as $quickReply) {
             if (!$quickReply instanceof QuickReply) {
                 throw new InvalidClassException(sprintf(


### PR DESCRIPTION
This caused to raise an exception in case of an empty array when using _addQuickReply_, or _setQuickReplies_.
This is a problem since since [this commit](https://github.com/ker0x/messenger/commit/f54e90c0014beb0ce5c588c0bdbc3383778fecbb#diff-d31d0ee2043bac0eba2dc950615c62a4) for _addQuickReply_, but I'm not sure about expected behaviour of _setQuickReplies_.
I simply removed the minimum, as an empty array is the default value anyway, and has to be supported anyway.

| Q             | A
| ------------- | ---
| Branch?       | 3.0.0
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | None   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
